### PR TITLE
Remove QoE calc error announcement

### DIFF
--- a/src/lib/data/pages/home.yaml
+++ b/src/lib/data/pages/home.yaml
@@ -20,7 +20,6 @@ ja:
       src: https://res.cloudinary.com/videomark/c_scale,w_800/pc/logview-03.jpg
       alt: Web VideoMark 計測結果画面
     more: もっと見る →
-  announcement: 現在、サーバーの不調により、体感品質値を算出できないことがあります。ご不便をお掛けしますが、復旧まで今しばらくお待ちください。
 en:
   meta:
     pageImage: null


### PR DESCRIPTION
不具合発生中バナーの撤去

通常のクライアントでの最新/最終 QoE 値が得られるように復旧しているため、不具合発生中メッセージを削除します